### PR TITLE
Enable secure MQTT support by parameterising the port number

### DIFF
--- a/examples/SecureMqtt/SecureMqtt.ino
+++ b/examples/SecureMqtt/SecureMqtt.ino
@@ -12,10 +12,6 @@ char *username = "........";    // fixed credentials can be registered in the Ad
 char *c8yPassword = "........"; // create a user in usermanagement with the "device"role and fill the credentials here
 char *tenant = "........";      //tenant ID can be found by clicking on your name in the top right corner of Cumulocity
 char *clientId = ".........";   //Should be a unique identifier for this device, e.g. IMEI, MAC address or SerialNumber
-const char *root_ca =
-    "-----BEGIN CERTIFICATE-----\n"
-    ".....CERT CONTENT............\n"
-    "-----END CERTIFICATE-----\n";
 
 WiFiClientSecure wifiClient;
 CumulocityClient c8yClient(wifiClient, clientId);
@@ -23,11 +19,9 @@ CumulocityClient c8yClient(wifiClient, clientId);
 void setup()
 {
     Serial.begin(115200);
-
-    wifiClient.setCACert(root_ca);
-    WiFi.begin(ssid, wifiPassword);
-
     Serial.print("Connecting to WiFi");
+
+    WiFi.begin(ssid, wifiPassword);
     while (WiFi.status() != WL_CONNECTED)
     {
         delay(500);

--- a/examples/SecureMqtt/SecureMqtt.ino
+++ b/examples/SecureMqtt/SecureMqtt.ino
@@ -1,0 +1,51 @@
+#include <CumulocityClient.h>
+#ifdef ESP8266
+    #include <ESP8266WiFi.h>
+#else //ESP32
+    #include <WiFiClientSecure.h>
+#endif
+
+const char *ssid = "........";
+const char *wifiPassword = "........";
+char *host = "xxx.cumulocity.com";
+char *username = "........";    // fixed credentials can be registered in the Administration section
+char *c8yPassword = "........"; // create a user in usermanagement with the "device"role and fill the credentials here
+char *tenant = "........";      //tenant ID can be found by clicking on your name in the top right corner of Cumulocity
+char *clientId = ".........";   //Should be a unique identifier for this device, e.g. IMEI, MAC address or SerialNumber
+const char *root_ca =
+    "-----BEGIN CERTIFICATE-----\n"
+    ".....CERT CONTENT............\n"
+    "-----END CERTIFICATE-----\n";
+
+WiFiClientSecure wifiClient;
+CumulocityClient c8yClient(wifiClient, clientId);
+
+void setup()
+{
+    Serial.begin(115200);
+
+    wifiClient.setCACert(root_ca);
+    WiFi.begin(ssid, wifiPassword);
+
+    Serial.print("Connecting to WiFi");
+    while (WiFi.status() != WL_CONNECTED)
+    {
+        delay(500);
+        Serial.print(".");
+    }
+    Serial.println("connected to wifi");
+
+    c8yClient.connect(host, 8883, tenant, username, c8yPassword);
+    c8yClient.registerDevice(clientId, "c8y_esp32");
+}
+
+void loop()
+{
+    delay(3000);
+    c8yClient.loop();
+
+    int8_t rssi = WiFi.RSSI();
+    char rssiStr[10];
+    sprintf(rssiStr, "%d", rssi);
+    c8yClient.createMeasurement("SignalStrength", "T", rssiStr, "*db");
+}

--- a/src/CumulocityClient.cpp
+++ b/src/CumulocityClient.cpp
@@ -22,10 +22,14 @@ bool CumulocityClient::reconnect() {
 }
 
 bool CumulocityClient::connect(char* host, char* tenant, char* user, char* password) {
+    return connect(host, 1883, tenant, user, password);
+}
 
+bool CumulocityClient::connect(char* host, uint16_t port, char* tenant, char* user, char* password) {
     Serial.printf("connect(%s,%s,%s)\n", host, tenant, user);
 
     _host = host;
+    _port = port;
     _credentials.tenant = tenant;
     _credentials.username = user;
     _credentials.password = password;
@@ -36,15 +40,20 @@ bool CumulocityClient::connect(char* host, char* tenant, char* user, char* passw
     _clientId = (char*) malloc(myClientId.length() +1);
     strcpy(_clientId,myClientId.c_str());
 
-    _client.setServer(_host, 1883);
+    _client.setServer(_host, _port);
 
     return connectClient();
 
 }
 
 bool CumulocityClient::connect(char* host, char* tenant, char* user, char* password, char* defaultTemplate) {
+    return connect(host, 1883, tenant, user, password, defaultTemplate);
+}
+
+bool CumulocityClient::connect(char* host, uint16_t port, char* tenant, char* user, char* password, char* defaultTemplate) {
 
     _host = host;
+    _port = port;
     _credentials.tenant = tenant;
     _credentials.username = user;
     _credentials.password = password;
@@ -57,7 +66,7 @@ bool CumulocityClient::connect(char* host, char* tenant, char* user, char* passw
     _clientId = (char*) malloc(myClientId.length() +1);
     strcpy(_clientId,myClientId.c_str());
 
-    _client.setServer(_host, 1883);
+    _client.setServer(_host, _port);
 
     return connectClient();
 

--- a/src/CumulocityClient.h
+++ b/src/CumulocityClient.h
@@ -39,7 +39,9 @@ class CumulocityClient {
 	
 	bool reconnect();
 	bool connect(char* host, char* tenant, char* user, char* password);
+	bool connect(char* host, uint16_t port, char* tenant, char* user, char* password);
 	bool connect(char* host, char* tenant, char* user, char* password, char* defaultTemplate);
+	bool connect(char* host, uint16_t port, char* tenant, char* user, char* password, char* defaultTemplate);
 	void disconnect();
 
 	void setDeviceCredentials(char* tenant, char* user, char* password);
@@ -65,6 +67,7 @@ class CumulocityClient {
 	PubSubClient _client;
 
 	char* _host;
+	uint16_t _port;
     Credentials _credentials;
 	char* _clientId;
 	bool _credentialsReceived;


### PR DESCRIPTION
Current implementation of the library assumes 1883 port number. This blocks library consumers from using secure mqtt which uses port 8883. This PR addresses this issue by:

- Add `connect()` overloads that accept port number as a parameter
- Add an example that demonstrates secure mqtt usage